### PR TITLE
Force gnu++98

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ ARMOBJCOPY=$(ARM)objcopy
 #
 # CXX Flags
 #
-COMMON_CXXFLAGS+=-Wall -Werror -MT $@ -MD -MP -MF $(@:%.o=%.d) -DVERSION=\"$(VERSION)\" -g -O2
+COMMON_CXXFLAGS+=-Wall -Werror -MT $@ -MD -MP -MF $(@:%.o=%.d) -DVERSION=\"$(VERSION)\" -g -O2 -std=gnu++98
 WX_CXXFLAGS:=-Wno-ctor-dtor-privacy -O2 -fno-strict-aliasing
 BOSSA_CXXFLAGS=$(COMMON_CXXFLAGS) $(WX_CXXFLAGS) 
 BOSSAC_CXXFLAGS=$(COMMON_CXXFLAGS)


### PR DESCRIPTION
To fix compilation bug on modern compilers:
src/SerialPort.h:74:18: error: ‘template<class> class std::auto_ptr’ is deprecated [-Werror=deprecated-declarations]
     typedef std::auto_ptr<SerialPort> Ptr;
Because:
"The default mode for C++ is now -std=gnu++14 instead of -std=gnu++98."