### PR TITLE
Fix buffer overflow

### DIFF
--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -181,7 +181,7 @@ Samba::disconnect()
 void
 Samba::writeByte(uint32_t addr, uint8_t value)
 {
-    uint8_t cmd[13];
+    uint8_t cmd[14];
 
     if (_debug)
         printf("%s(addr=%#x,value=%#x)\n", __FUNCTION__, addr, value);


### PR DESCRIPTION
Fix compilation error:
src/Samba.cpp:182:1: error: ‘snprintf’ output truncated before the last format character [-Werror=format-truncation=]
 Samba::writeByte(uint32_t addr, uint8_t value)
 ^~~~~
src/Samba.cpp:189:13: note: ‘snprintf’ output 14 bytes into a destination of size 13